### PR TITLE
Make the MockTransport example more robust/correct

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -1100,7 +1100,7 @@ def handler(request):
 
 
 # Switch to a mock transport, if the TESTING environment variable is set.
-if os.environ['TESTING'].upper() == "TRUE":
+if os.environ.get('TESTING', '').upper() == "TRUE":
     transport = httpx.MockTransport(handler)
 else:
     transport = httpx.HTTPTransport()


### PR DESCRIPTION
The current [Mock transports](https://www.python-httpx.org/advanced/#mock-transports) example reads:
```
# Switch to a mock transport, if the TESTING environment variable is set.
```
However, at the time of writing this, if the `TESTING` envvar is not set, a `KeyError` would be raised instead of following the `HTTPTransport` branch.